### PR TITLE
Updated access token key

### DIFF
--- a/docs/source/pydaisi/authentication.rst
+++ b/docs/source/pydaisi/authentication.rst
@@ -49,7 +49,7 @@ environment variable as follow:
 .. code-block:: python
 
     import os
-    os.environ["ACCESS_TOKEN"] = <your access token>
+    os.environ["DAISI_ACCESS_TOKEN"] = <your access token>
 
 
 With a Shell environment variable


### PR DESCRIPTION
Changed 'ACCESS_TOKEN' key to 'DAISI_ACCESS_TOKEN' to sync with new version of docs.